### PR TITLE
Fix/args bug

### DIFF
--- a/get_commits.sh
+++ b/get_commits.sh
@@ -52,4 +52,4 @@ check_commits "$1" "$4" "$5" && echo "There is a new commit to ${1}! Creating is
 create_issue "$1" "$2" "$3" && echo ::set-output name=issue_url::${issueURL}
 exit 0
 }
-main ${INPUT_SOURCEREPO:-$1} ${INPUT_TARGETREPO:-$2} ${INPUT_ISSUELABELS:-${3:-""}} ${INPUT_TIMEUNTIL:-${4:-$UNTIL}} ${INPUT_TIMEFRAME:-${5:-$TIMEFRAME}}
+main "${INPUT_SOURCEREPO:-$1}" "${INPUT_TARGETREPO:-$2}" "${INPUT_ISSUELABELS:-${3:-""}}" "${INPUT_TIMEUNTIL:-${4:-$UNTIL}}" "${INPUT_TIMEFRAME:-${5:-$TIMEFRAME}}"

--- a/spec/commit-issue-action_spec.sh
+++ b/spec/commit-issue-action_spec.sh
@@ -17,6 +17,12 @@ Describe "mock date to known commit"
     The output should include "There is a new commit"
     The output should include "Issue created"
   End
+  It "runs script with recent commits and more labels"
+    When run script get_commits.sh "wescran/commit-issue-action" "wescran/commit-issue-action" "shellspec, test, Status: Available" "1574124013"
+    The status should be success
+    The output should include "There is a new commit"
+    The output should include "Issue created"
+  End
 End
 Describe "short time frame"
   It "runs script with no recent commits"


### PR DESCRIPTION
There was a bug where the whitespace in the input argument for the issue labels was causing errors. Added double quotes in order for the whitespace to be preserved. Added new test for such issues